### PR TITLE
Optimize TensorOps.MatMul2D

### DIFF
--- a/src/Lokad.Onnx.CLI/Benchmarks.cs
+++ b/src/Lokad.Onnx.CLI/Benchmarks.cs
@@ -44,7 +44,7 @@ public class MatMul2DBenchmarks : Runtime
         bh_2 = t_1536_384_b.ToDenseTensor().Buffer.Pin();
     }
 
-    [Benchmark(Description = "Multiply 2 384x384 matrices - managed", Baseline = true)]
+    [Benchmark(Description = "Multiply 2 384x384 matrices - managed")]
     public void MatMul2D_1() =>
         mm_managed(384, 384, 384, t_384_384_a.ToDenseTensor().Buffer, t_384_384_a.ToDenseTensor().Buffer, t_384_384_c.ToDenseTensor().Buffer);
 
@@ -60,10 +60,13 @@ public class MatMul2DBenchmarks : Runtime
     public unsafe void MatMul2D_4() =>
        mm_unsafe_vectorized(384, 384, 384, (float*)ah_1.Pointer, (float*)bh_1.Pointer, (float*)ch.Pointer);
 
-    [Benchmark(Description = "Multiply 2 384x384 matrices - unsafe simd intrinsics")]
+    [Benchmark(Description = "Multiply 2 384x384 matrices - unsafe simd intrinsics", Baseline = true)]
     public unsafe void MatMul2D_5() =>
       mm_unsafe_vectorized_intrinsics(384, 384, 384, (float*)ah_1.Pointer, (float*)bh_1.Pointer, (float*)ch.Pointer);
 
+    [Benchmark(Description = "Multiply 2 384x384 matrices - unsafe simd intrinsics pointers 2x4")]
+    public unsafe void MatMul2D_6() =>
+      mm_unsafe_vectorized_intrinsics_2x4(384, 384, 384, (float*)ah_1.Pointer, (float*)bh_1.Pointer, (float*)ch.Pointer);
     #region Fields
     Tensor<float> t_384_384_a = Tensor<float>.Zeros(0);
     Tensor<float> t_384_384_b = Tensor<float>.Zeros(0);

--- a/src/Lokad.Onnx.Tensors/MathOps.cs
+++ b/src/Lokad.Onnx.Tensors/MathOps.cs
@@ -3,6 +3,7 @@ using System.Numerics;
 using System.Runtime.Intrinsics.X86;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
+using System.Diagnostics;
 
 namespace Lokad.Onnx;
 
@@ -486,6 +487,107 @@ public class MathOps
                 for (int k = ceiling; k < K; k++)
                 {
                     Cp[k] += a * Bp[k];
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Matrix multiplication.
+    /// </summary>
+    /// <param name="M">A rows.</param>
+    /// <param name="N">A columns.</param>
+    /// <param name="K">B columns.</param>
+    /// <param name="A">Left matrix.</param>
+    /// <param name="B">Right matrix.</param>
+    /// <param name="C">Result matrix.</param>
+    public unsafe static void mm_unsafe_vectorized_intrinsics_2x4(int M,
+                          int N,
+                          int K,
+                          float* A,
+                          float* B,
+                          float* C)
+    {
+
+        // Optimizations: 
+        //
+        //  - Process the output two lines at a time (to halve the number of loads from B),
+        //    and assume that M is even to avoid having dedicated code for a last odd line.
+        //
+        //  - Manually 4x unroll the inner loop, and assume that K is a multiple of 32 
+        //    to avoid having dedicated code for the remainder of lines.
+        //
+        //  - Use pointers and casts instead of span, in order to avoid overhead from bounds
+        //    checking. The #if DEBUG lines are here to protect against out-of-bounds in 
+        //    debug mode.
+
+        if (M % 2 != 0)
+            throw new ArgumentException(nameof(M));
+
+        if (K % (4 * Vector256<float>.Count) != 0)
+            throw new ArgumentException(nameof(K));
+
+#if DEBUG
+        var Aend = A + M * N;
+        var Bend = B + N * K;
+        var Cend = C + M * K;
+#endif
+
+        for (int i = 0; i < M; i += 2)
+        {
+            var Ap1 = A + i * N;
+            var Ap2 = A + N;
+
+            var Cp1 = C + i * K;
+            var Cp2 = Cp1 + K;
+
+            for (int j = 0; j < N; ++j)
+            {
+#if DEBUG
+                Debug.Assert(Ap1 + j < Aend);
+                Debug.Assert(Ap2 + j < Aend);
+#endif
+                var av1 = Vector256.Create(Ap1[j]);
+                var av2 = Vector256.Create(Ap2[j]);
+
+                var Bp = B + j * K;
+
+                var Bpv = (Vector256<float>*)Bp;
+                var Cpv1 = (Vector256<float>*)Cp1;
+                var Cpv2 = (Vector256<float>*)Cp2;
+                var Bepv = (Vector256<float>*)(Bp + K);
+
+#if DEBUG
+                Debug.Assert(Bepv <= Bend);
+#endif
+
+                while (Bpv < Bepv)
+                {
+#if DEBUG
+                    Debug.Assert(Cpv1 + 3 < Cend);
+                    Debug.Assert(Cpv2 + 3 < Cend);
+#endif
+                    Vector256<float> bv;
+
+                    bv = Bpv[0];
+                    Cpv1[0] = Fma.MultiplyAdd(bv, av1, Cpv1[0]);
+                    Cpv2[0] = Fma.MultiplyAdd(bv, av2, Cpv2[0]);
+
+                    bv = Bpv[1];
+                    Cpv1[1] = Fma.MultiplyAdd(bv, av1, Cpv1[1]);
+                    Cpv2[1] = Fma.MultiplyAdd(bv, av2, Cpv2[1]);
+
+                    bv = Bpv[2];
+                    Cpv1[2] = Fma.MultiplyAdd(bv, av1, Cpv1[2]);
+                    Cpv2[2] = Fma.MultiplyAdd(bv, av2, Cpv2[2]);
+
+                    bv = Bpv[3];
+                    Cpv1[3] = Fma.MultiplyAdd(bv, av1, Cpv1[3]);
+                    Cpv2[3] = Fma.MultiplyAdd(bv, av2, Cpv2[3]);
+
+                    Bpv += 4;
+                    Cpv1 += 4;
+                    Cpv2 += 4;
                 }
             }
         }

--- a/src/Lokad.Onnx.Tensors/TensorOps.cs
+++ b/src/Lokad.Onnx.Tensors/TensorOps.cs
@@ -370,9 +370,19 @@ where T : unmanaged
         var oh = output.Buffer.Pin();
         if (HardwareConfig.UseSimd && HardwareConfig.UseIntrinsics && Fma.IsSupported)
         {
-            unsafe
+            if (m % 2 == 0 && k % 32 == 0)
             {
-                mm_unsafe_vectorized_intrinsics(m, n, k, (float*)xh.Pointer, (float*)yh.Pointer, (float*)oh.Pointer);
+                unsafe
+                {
+                    mm_unsafe_vectorized_intrinsics_2x4(m, n, k, (float*)xh.Pointer, (float*)yh.Pointer, (float*)oh.Pointer);
+                }
+            }
+            else
+            {
+                unsafe
+                {
+                    mm_unsafe_vectorized_intrinsics(m, n, k, (float*)xh.Pointer, (float*)yh.Pointer, (float*)oh.Pointer);
+                }
             }
         }
         else if (HardwareConfig.UseSimd)
@@ -387,7 +397,7 @@ where T : unmanaged
             unsafe
             {
                 mm(m, n, k, (float*)xh.Pointer, (float*)yh.Pointer, (float*)oh.Pointer);
-            }     
+            }
         }
         xh.Dispose();
         yh.Dispose();


### PR DESCRIPTION
This introduces a new `mm_unsafe_vectorized_intrinsics_2x4` method that runs in 60% of the time of `mm_unsafe_vectorized_intrinsics`, but with the requirement that the first and last dimensions are multiples of 2 and 32 respectively.

With these changes, the assembly produced for the innermost loop is: 

```asm
    L00d5: vmovups ymm2, [r12]
    L00db: vmovaps ymm3, ymm2
    L00df: vfmadd213ps ymm3, ymm0, [r10]
    L00e4: vmovups [r10], ymm3
    L00e9: vfmadd213ps ymm2, ymm1, [rbx]
    L00ee: vmovups [rbx], ymm2
    L00f2: vmovups ymm2, [r12+0x20]
    L00f9: vmovaps ymm3, ymm2
    L00fd: vfmadd213ps ymm3, ymm0, [r10+0x20]
    L0103: vmovups [r10+0x20], ymm3
    L0109: vfmadd213ps ymm2, ymm1, [rbx+0x20]
    L010f: vmovups [rbx+0x20], ymm2
    L0114: vmovups ymm2, [r12+0x40]
    L011b: vmovaps ymm3, ymm2
    L011f: vfmadd213ps ymm3, ymm0, [r10+0x40]
    L0125: vmovups [r10+0x40], ymm3
    L012b: vfmadd213ps ymm2, ymm1, [rbx+0x40]
    L0131: vmovups [rbx+0x40], ymm2
    L0136: vmovups ymm2, [r12+0x60]
    L013d: vmovaps ymm3, ymm2
    L0141: vfmadd213ps ymm3, ymm0, [r10+0x60]
    L0147: vmovups [r10+0x60], ymm3
    L014d: vfmadd213ps ymm2, ymm1, [rbx+0x60]
    L0153: vmovups [rbx+0x60], ymm2
    L0158: add r12, 0x80
    L015f: add r10, 0x80
    L0166: add rbx, 0x80
    L016d: cmp r12, r9
    L0170: jb L00d5
```

Compared to the previous version: 

```asm
    L0100: cmp ecx, r12d
    L0103: jae L0246
    L0109: mov eax, ecx
    L010b: shl rax, 5
    L010f: lea rbx, [r9+rax]
    L0113: vmovups ymm2, [rax+r13]
    L0119: vfmadd213ps ymm2, ymm1, [rbx]
    L011e: vmovups [rbx], ymm2
    L0122: inc ecx
    L0124: cmp ecx, r10d
    L0127: jl short L0100
    L0129: cmp r15d, r8d
```

The bounds check `cmp ecx, r12` is gone, the `shl rax, 5` is removed by incrementing pointers instead of indices, there are now two `vfmadd213ps` instead of one for every matrix row read (i.e. reading from the matrix half as many times), and the loop is manually unrolled 4 times.

The benchmark now includes this version as well, and uses the `mm_unsafe_vectorized_intrinsics` as the baseline. 