### PR TITLE
Enable intrinsics and skip MatMul2D densify for dense inputs

### DIFF
--- a/src/Lokad.Onnx.Base/HardwareConfig.cs
+++ b/src/Lokad.Onnx.Base/HardwareConfig.cs
@@ -4,7 +4,7 @@ public static class HardwareConfig
 {
     public static bool UseSimd { get; set; } = true;
 
-    public static bool UseIntrinsics { get; set; } = false;
+    public static bool UseIntrinsics { get; set; } = HardwareIntrinsics.IsX86FmaSupported;
 
     public static void EnableIntrinsics()
     {

--- a/src/Lokad.Onnx.CLI/Program.cs
+++ b/src/Lokad.Onnx.CLI/Program.cs
@@ -194,6 +194,7 @@ class Program : Runtime
         if (ro.DisableSimd)
         {
             HardwareConfig.UseSimd = false;
+            HardwareConfig.UseIntrinsics = false;
             Info("CPU SIMD features disabled.");
         }
         else
@@ -206,9 +207,12 @@ class Program : Runtime
             }
         }
         
-        if (ro.EnableIntrinsics && System.Numerics.Vector.IsHardwareAccelerated)
+        if (!ro.DisableSimd && System.Numerics.Vector.IsHardwareAccelerated)
         {
-            HardwareConfig.UseIntrinsics = true;
+            HardwareConfig.UseIntrinsics = (ro.EnableIntrinsics || HardwareConfig.UseIntrinsics);
+        }
+        if (HardwareConfig.UseIntrinsics)
+        {
             Info("CPU SIMD available intrinsics: {s}.", HardwareIntrinsics.GetFullInfo());
         }
         else

--- a/src/Lokad.Onnx.Tensors/TensorOps.cs
+++ b/src/Lokad.Onnx.Tensors/TensorOps.cs
@@ -325,8 +325,10 @@ where T : unmanaged
         var n = x.Dimensions[1];
         var k = y.Dimensions[1];
 
-        var _x = x.ToDenseTensor();
-        var _y = y.ToDenseTensor();
+        var dx = x as DenseTensor<int>;
+        var dy = y as DenseTensor<int>;
+        var _x = dx is not null && !dx.IsReversedStride ? dx : x.ToDenseTensor();
+        var _y = dy is not null && !dy.IsReversedStride ? dy : y.ToDenseTensor();
         var output = DenseTensor<int>.OfShape(new int[] { x.Dimensions[0], y.Dimensions[1] });
 
         var xh = _x.Buffer.Pin();
@@ -363,9 +365,16 @@ where T : unmanaged
         var n = x.Dimensions[1];
         var k = y.Dimensions[1];
 
-        StartOpStage(OpStage.Copy);
-        var _x = x.ToDenseTensor();
-        var _y = y.ToDenseTensor();
+        var dx = x as DenseTensor<float>;
+        var dy = y as DenseTensor<float>;
+        var needsCopyX = dx is null || dx.IsReversedStride;
+        var needsCopyY = dy is null || dy.IsReversedStride;
+        if (needsCopyX || needsCopyY)
+        {
+            StartOpStage(OpStage.Copy);
+        }
+        var _x = needsCopyX ? x.ToDenseTensor() : dx!;
+        var _y = needsCopyY ? y.ToDenseTensor() : dy!;
         var output = DenseTensor<float>.OfShape(new int[] { x.Dimensions[0], y.Dimensions[1] });
 
         StartOpStage(OpStage.Math);
@@ -416,8 +425,10 @@ where T : unmanaged
         var k = y.Dimensions[1];
 
 
-        var _x = x.ToDenseTensor();
-        var _y = y.ToDenseTensor();
+        var dx = x as DenseTensor<double>;
+        var dy = y as DenseTensor<double>;
+        var _x = dx is not null && !dx.IsReversedStride ? dx : x.ToDenseTensor();
+        var _y = dy is not null && !dy.IsReversedStride ? dy : y.ToDenseTensor();
         var output = DenseTensor<double>.OfShape(new int[] { x.Dimensions[0], y.Dimensions[1] });
 
         var xh = _x.Buffer.Pin();

--- a/tests/Lokad.Onnx.Tensors.Tests/TensorOpsMatMul2DTests.cs
+++ b/tests/Lokad.Onnx.Tensors.Tests/TensorOpsMatMul2DTests.cs
@@ -87,6 +87,9 @@ public class TensorOpsMatMul2DTests
         var a = DenseTensor<float>.OfValues(new float[,] { { 1f, 2f }, { 3f, 4f } });
         var b = DenseTensor<float>.OfValues(new float[,] { { 5f, 6f }, { 7f, 8f } });
 
+        using var _ = new HardwareConfigScope(HardwareConfig.UseSimd, HardwareConfig.UseIntrinsics);
+        Assert.Equal(HardwareIntrinsics.IsX86FmaSupported, HardwareConfig.UseIntrinsics);
+
         using var baseline = new HardwareConfigScope(useSimd: false, useIntrinsics: false);
         var scalar = Tensor<float>.MatMul2D(a, b);
 
@@ -100,6 +103,47 @@ public class TensorOpsMatMul2DTests
             var intrinsicsResult = Tensor<float>.MatMul2D(a, b);
             Assert.Equal(scalar, intrinsicsResult);
         }
+    }
+
+    [Fact]
+    public void MatMul2D_DenseVsReversedStride_MatchesManaged()
+    {
+        var ax = new float[,] { { 1f, 2f, 3f }, { 4f, 5f, 6f } };
+        var by = new float[,] { { 7f, 8f }, { 9f, 10f }, { 11f, 12f } };
+
+        var revX = ax.ToTensor<float>(reverseStride: true);
+        var revY = by.ToTensor<float>(reverseStride: true);
+
+        var denseX = revX.ToDenseTensor();
+        var denseY = revY.ToDenseTensor();
+        var expected = Tensor<float>.MatMul2D(denseX, denseY);
+        var reversedResult = Tensor<float>.MatMul2D(revX, revY);
+
+        Assert.Equal(expected[0, 0], reversedResult[0, 0], 5);
+        Assert.Equal(expected[1, 1], reversedResult[1, 1], 5);
+    }
+
+    [Fact]
+    public void MatMul2D_IntrinsicsBranch_LargeK_MatchesManaged()
+    {
+        if (!HardwareIntrinsics.IsX86FmaSupported)
+        {
+            return;
+        }
+
+        var x = Tensor<float>.Ones(2, 32);
+        var y = Tensor<float>.Ones(32, 32);
+
+        using var intrinsics = new HardwareConfigScope(useSimd: true, useIntrinsics: true);
+        Tensor<float> expected;
+        using (new HardwareConfigScope(useSimd: false, useIntrinsics: false))
+        {
+            expected = Tensor<float>.MatMul2D(x, y);
+        }
+        var actual = Tensor<float>.MatMul2D(x, y);
+
+        Assert.Equal(expected[0, 0], actual[0, 0], 5);
+        Assert.Equal(expected[1, 31], actual[1, 31], 5);
     }
 
     [Fact]

--- a/tests/Lokad.Onnx.Tensors.Tests/TestHelpers.cs
+++ b/tests/Lokad.Onnx.Tensors.Tests/TestHelpers.cs
@@ -4,11 +4,15 @@ namespace Lokad.Onnx.Tensors.Tests;
 
 internal sealed class HardwareConfigScope : IDisposable
 {
+    private static readonly object sync = new();
+    private readonly bool lockHeld;
     private readonly bool useSimd;
     private readonly bool useIntrinsics;
 
     public HardwareConfigScope(bool useSimd, bool useIntrinsics)
     {
+        System.Threading.Monitor.Enter(sync);
+        lockHeld = true;
         this.useSimd = HardwareConfig.UseSimd;
         this.useIntrinsics = HardwareConfig.UseIntrinsics;
         HardwareConfig.UseSimd = useSimd;
@@ -19,5 +23,9 @@ internal sealed class HardwareConfigScope : IDisposable
     {
         HardwareConfig.UseSimd = useSimd;
         HardwareConfig.UseIntrinsics = useIntrinsics;
+        if (lockHeld)
+        {
+            System.Threading.Monitor.Exit(sync);
+        }
     }
 }


### PR DESCRIPTION
Perf (Benchmark20_1_simd_intrinsics, IterationCount=200, WarmupCount=1, InProcess):
- net10 mean: 67.31 ms
- net10-perf mean: 40.20 ms (~1.67x faster, -27.11 ms)

Env: Intel Xeon W-2223, .NET 10.0.1, AVX-512F+CD+BW+DQ+VL.

Output check: last_hidden_state payload matches between net10 and net10-perf for 'Hello world this is some text' (timestamp stripped, --disable-simd).