### PR TITLE
Add DINOv2 ONNX runtime support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,33 @@
 # Lokad.Onnx
 
 ## About
-Lokad.Onnx is a 100% managed code [ONNX backend](https://github.com/onnx/onnx/blob/main/docs/ImplementingAnOnnxBackend.md) implementation.
+Lokad.Onnx is a 100% managed code [ONNX backend](https://onnx.ai/onnx/repo-docs/ImplementingAnOnnxBackend.html) implementation.
 
 ![img](https://ajb.nyc3.cdn.digitaloceanspaces.com/lokadonnx8.gif)
 
 ## Getting started
-* Clone the repo and submodules: `git clone https://github.com/Lokad/Onnx.git --recurse-submodules`.
-* Run `build.cmd` from the repo root directory
-* Run `lonnx --help` to show the available CLI commands. The basic command syntax for running an ONNX model is:
-  	`lonnx run (modelpathorurl) (input) --<options>`
-  e.g `lonnx run .\tests\Lokad.Onnx.Backend.Tests\models\mnist-8.onnx  .\tests\Lokad.Onnx.Backend.Tests\images\mnist4.png::mnist --softmax`
-  will run the MNIST model at the path indicated using the image file indicated as input converted to the MNIST tensor shape 1x1x28x28. For language models you can say
-  `lonnx run https://huggingface.co/intfloat/multilingual-e5-small/resolve/main/onnx/model.onnx?download=true --text "me5s" "Hello world this is some text" --print-input`
-  To download and run the language model from the URL indicated using the text input converted to input tensors 1x[tokennum] using the multilingual-e5-small tokenizer, printing the model input.
-  For a local model download (git-ignored), you can do:
+* Clone the repo: `git clone https://github.com/Lokad/Onnx.git`
+* Run `build.cmd` from the repo root directory.
+* Run `lonnx.cmd --help` to show the available CLI commands. The basic syntax is:
+  `lonnx.cmd run (modelpathorurl) (input) --<options>`
+
+### Mini-tutorial: MNIST (image)
+* Use the bundled MNIST model and sample image:
+  `lonnx.cmd run .\tests\Lokad.Onnx.Backend.Tests\models\mnist-8.onnx .\tests\Lokad.Onnx.Backend.Tests\images\mnist4.png::mnist --softmax`
+
+### Mini-tutorial: multilingual-e5-small (text)
+* Download the model:
   `mkdir models\multilingual-e5-small; powershell -Command "Invoke-WebRequest -Uri https://huggingface.co/intfloat/multilingual-e5-small/resolve/main/onnx/model.onnx?download=true -OutFile models\multilingual-e5-small\model.onnx"`
-  Then run:
-  `lonnx run .\models\multilingual-e5-small\model.onnx --text "me5s" "Hello world this is some text" --print-input`
-* See the [unit tests](https://github.com/Lokad/Onnx/blob/master/tests/Lokad.Onnx.Backend.Tests/GraphTests.cs) for example on how to use the library in your own .NET apps.
+* Run with a short text:
+  `lonnx.cmd run .\models\multilingual-e5-small\model.onnx --text "me5s" "Hello world this is some text" --print-input`
+
+### Mini-tutorial: DINOv2-small (image)
+* Download the model:
+  `mkdir models\dinov2-small-onnx; powershell -Command "Invoke-WebRequest -Uri https://huggingface.co/onnx-community/dinov2-small-ONNX/resolve/main/onnx/model.onnx -OutFile models\dinov2-small-onnx\model.onnx"`
+* Run with an image (224x224 resize, RGB channels in [0,1] range; no mean/std normalization yet):
+  `lonnx.cmd run .\models\dinov2-small-onnx\model.onnx .\path\to\image.jpg::dinov2`
+
+* See the [unit tests](https://github.com/Lokad/Onnx/blob/master/tests/Lokad.Onnx.Backend.Tests/GraphExecutionMnistTests.cs) for examples of using the library in .NET.
 * The modules for using the backend from Python are [here](https://github.com/Lokad/Onnx/tree/master/src/interop) and can be imported into Python apps in the usual way.
 
 ## Implementation notes

--- a/build.cmd
+++ b/build.cmd
@@ -20,7 +20,7 @@ if not %ERRORLEVEL%==0  (
 
 echo Building Lokad Onnx Python interop project..
 cd src\Lokad.Onnx.Interop
-dotnet publish --tl:off --nologo -v minimal Lokad.Onnx.Interop.csproj -f net6.0 -p:PublishProfile=FolderProfile
+dotnet publish --tl:off --nologo -v minimal Lokad.Onnx.Interop.csproj -p:PublishProfile=FolderProfile
 if not %ERRORLEVEL%==0  (
     echo Error building Lokad.ONNX projects.
     set ERROR_CODE=2

--- a/src/Lokad.Onnx.Backend/CPUExecutionProvider.cs
+++ b/src/Lokad.Onnx.Backend/CPUExecutionProvider.cs
@@ -42,6 +42,10 @@ public class CPUExecutionProvider : Runtime
         OpType.Shape,
         OpType.Gather,
         OpType.Slice,
+        OpType.Equal,
+        OpType.Where,
+        OpType.Expand,
+        OpType.Resize,
         OpType.Unsqueeze,
         OpType.ReduceSum,
         OpType.ReduceMean,
@@ -199,6 +203,8 @@ public class CPUExecutionProvider : Runtime
         switch (A.ElementType)
         {
             case TensorElementType.UInt8: return Success(op, Tensor<byte>.Divide((Tensor<byte>)bA, (Tensor<byte>)bB));
+            case TensorElementType.Int32: return Success(op, Tensor<int>.Divide((Tensor<int>)bA, (Tensor<int>)bB));
+            case TensorElementType.Int64: return Success(op, Tensor<long>.Divide((Tensor<long>)bA, (Tensor<long>)bB));
             case TensorElementType.Float: return Success(op, Tensor<float>.Divide((Tensor<float>)bA, (Tensor<float>)bB));
             case TensorElementType.Double: return Success(op, Tensor<double>.Divide((Tensor<double>)bA, (Tensor<double>)bB));
             default: return InputTypeNotSupported(op, nameof(A), A);
@@ -596,6 +602,125 @@ public class CPUExecutionProvider : Runtime
             case TensorElementType.BFloat16: return Success(op, Tensor<BFloat16>.Slice((Tensor<BFloat16>)data, (Tensor<int>) starts, (Tensor<int>) ends, (Tensor<int>?) axes, (Tensor<int>?) steps));
             case TensorElementType.Complex64: return Success(op, Tensor<System.Numerics.Complex>.Slice((Tensor<System.Numerics.Complex>)data, (Tensor<int>) starts, (Tensor<int>) ends, (Tensor<int>?) axes, (Tensor<int>?) steps));
             default: return NotSupported(op);
+        }
+    }
+
+    public static OpResult Equal(ITensor? A, ITensor? B)
+    {
+        var op = OpType.Equal;
+        if (A is null) return MissingInput(op, nameof(A));
+        if (B is null) return MissingInput(op, nameof(B));
+        if (A.ElementType != B.ElementType)
+        {
+            return WrongInputType(op, nameof(B), "Input tensors must be of the same type.", B);
+        }
+        switch (A.ElementType)
+        {
+            case TensorElementType.Bool: return Success(op, Tensor<bool>.Equal((Tensor<bool>)A, (Tensor<bool>)B));
+            case TensorElementType.Int32: return Success(op, Tensor<int>.Equal((Tensor<int>)A, (Tensor<int>)B));
+            case TensorElementType.Int64: return Success(op, Tensor<long>.Equal((Tensor<long>)A, (Tensor<long>)B));
+            case TensorElementType.Float: return Success(op, Tensor<float>.Equal((Tensor<float>)A, (Tensor<float>)B));
+            case TensorElementType.Double: return Success(op, Tensor<double>.Equal((Tensor<double>)A, (Tensor<double>)B));
+            default: return InputTypeNotSupported(op, nameof(A), A);
+        }
+    }
+
+    public static OpResult Where(ITensor? condition, ITensor? X, ITensor? Y)
+    {
+        var op = OpType.Where;
+        if (condition is null) return MissingInput(op, nameof(condition));
+        if (X is null) return MissingInput(op, nameof(X));
+        if (Y is null) return MissingInput(op, nameof(Y));
+        if (condition.ElementType != TensorElementType.Bool) return WrongInputType(op, nameof(condition), TensorElementType.Bool, condition);
+        if (X.ElementType != Y.ElementType)
+        {
+            return WrongInputType(op, nameof(Y), "Input tensors must be of the same type.", Y);
+        }
+        switch (X.ElementType)
+        {
+            case TensorElementType.Bool: return Success(op, Tensor<bool>.Where((Tensor<bool>)condition, (Tensor<bool>)X, (Tensor<bool>)Y));
+            case TensorElementType.Int32: return Success(op, Tensor<int>.Where((Tensor<bool>)condition, (Tensor<int>)X, (Tensor<int>)Y));
+            case TensorElementType.Int64: return Success(op, Tensor<long>.Where((Tensor<bool>)condition, (Tensor<long>)X, (Tensor<long>)Y));
+            case TensorElementType.Float: return Success(op, Tensor<float>.Where((Tensor<bool>)condition, (Tensor<float>)X, (Tensor<float>)Y));
+            case TensorElementType.Double: return Success(op, Tensor<double>.Where((Tensor<bool>)condition, (Tensor<double>)X, (Tensor<double>)Y));
+            default: return InputTypeNotSupported(op, nameof(X), X);
+        }
+    }
+
+    public static OpResult Expand(ITensor? data, ITensor? shape)
+    {
+        var op = OpType.Expand;
+        if (data is null) return MissingInput(op, nameof(data));
+        if (shape is null) return MissingInput(op, nameof(shape));
+        if (shape.ElementType == TensorElementType.Int64)
+        {
+            shape = shape.ConvertToInt32();
+        }
+        if (shape.ElementType != TensorElementType.Int32) return WrongInputType(op, nameof(shape), TensorElementType.Int32, shape);
+
+        var targetShape = ((Tensor<int>)shape).ToArray();
+        switch (data.ElementType)
+        {
+            case TensorElementType.Bool: return Success(op, Tensor<bool>.Expand((Tensor<bool>)data, targetShape));
+            case TensorElementType.Int32: return Success(op, Tensor<int>.Expand((Tensor<int>)data, targetShape));
+            case TensorElementType.Int64: return Success(op, Tensor<long>.Expand((Tensor<long>)data, targetShape));
+            case TensorElementType.Float: return Success(op, Tensor<float>.Expand((Tensor<float>)data, targetShape));
+            case TensorElementType.Double: return Success(op, Tensor<double>.Expand((Tensor<double>)data, targetShape));
+            default: return InputTypeNotSupported(op, nameof(data), data);
+        }
+    }
+
+    public static OpResult Resize(ITensor? X, ITensor? roi, ITensor? scales, ITensor? sizes,
+        string? mode, string? coordinateTransformationMode, string? nearestMode, float? cubicCoeffA, float? extrapolationValue)
+    {
+        var op = OpType.Resize;
+        if (X is null) return MissingInput(op, nameof(X));
+        if (sizes is null && scales is null) return MissingInput(op, nameof(sizes));
+        if (sizes is not null && sizes.ElementType == TensorElementType.Int64)
+        {
+            sizes = sizes.ConvertToInt32();
+        }
+        if (sizes is not null && sizes.ElementType != TensorElementType.Int32)
+        {
+            return WrongInputType(op, nameof(sizes), TensorElementType.Int32, sizes);
+        }
+
+        int[] targetSizes;
+        if (sizes is not null)
+        {
+            targetSizes = ((Tensor<int>)sizes).ToArray();
+        }
+        else
+        {
+            if (scales is null) return MissingInput(op, nameof(scales));
+            if (scales.ElementType != TensorElementType.Float && scales.ElementType != TensorElementType.Double)
+            {
+                return WrongInputType(op, nameof(scales), "Scales must be float or double.", scales);
+            }
+            var dims = X.Dims;
+            var scaleArray = scales.ElementType == TensorElementType.Float
+                ? ((Tensor<float>)scales).ToArray().Select(s => (double)s).ToArray()
+                : ((Tensor<double>)scales).ToArray();
+            if (scaleArray.Length != dims.Length)
+            {
+                return WrongInputShape(op, nameof(scales), dims.Length, scales);
+            }
+            targetSizes = dims.Select((d, i) => Convert.ToInt32(Math.Round(d * scaleArray[i]))).ToArray();
+        }
+
+        var resizeMode = mode ?? "nearest";
+        var ctm = coordinateTransformationMode ?? "half_pixel";
+        var nm = nearestMode ?? "round_prefer_floor";
+        var cubicA = cubicCoeffA ?? -0.75f;
+
+        switch (X.ElementType)
+        {
+            case TensorElementType.Float:
+                return Success(op, Tensor<float>.Resize((Tensor<float>)X, targetSizes, resizeMode, ctm, nm, cubicA));
+            case TensorElementType.Double:
+                return Success(op, Tensor<double>.Resize((Tensor<double>)X, targetSizes, resizeMode, ctm, nm, cubicA));
+            default:
+                return InputTypeNotSupported(op, nameof(X), X);
         }
     }
 

--- a/src/Lokad.Onnx.Backend/ComputationalGraph.cs
+++ b/src/Lokad.Onnx.Backend/ComputationalGraph.cs
@@ -27,6 +27,12 @@ public class ComputationalGraph : Runtime
     public Dictionary<string, object> Metadata = new Dictionary<string, object>();
 
     public Dictionary<string, string> MetadataProps = new Dictionary<string, string>();
+
+    public string? LastErrorMessage { get; private set; }
+
+    public string? LastFailedNodeName { get; private set; }
+
+    public OpType? LastFailedNodeOp { get; private set; }
     #endregion
 
     #region Methods
@@ -39,7 +45,8 @@ public class ComputationalGraph : Runtime
     public ITensor? GetInputTensor(string[] Inputs, int index) =>
        index < Inputs.Length ? GetInputTensor(Inputs[index]) : null;    
 
-    public ITensor[] GetInputTensors(string[] names) => names.Select(n => GetInputTensor(n)).ToArray();
+    public ITensor[] GetInputTensors(string[] names) =>
+        names.Where(n => !string.IsNullOrEmpty(n)).Select(n => GetInputTensor(n)).ToArray();
 
     public Dictionary<string, ITensor> GetRequiredInputs(bool useInitializers)
     {
@@ -194,6 +201,9 @@ public class ComputationalGraph : Runtime
 
     public bool Execute(object userInputs, bool useInitializers, ExecutionProvider provider = ExecutionProvider.CPU)
     {
+        LastErrorMessage = null;
+        LastFailedNodeName = null;
+        LastFailedNodeOp = null;
         if (userInputs is ITensor[] uia)
         {
             if (!ResolveInputs(uia, useInitializers))
@@ -242,6 +252,9 @@ public class ComputationalGraph : Runtime
             {
                 Error("Execution of node {c} {n} with op {op} failed: {m}", count, node.Name, node.Op, r.Message ?? "");
                 Error("Stopping graph execution at node {c} {n}.", count, node.Name);
+                LastErrorMessage = r.Message;
+                LastFailedNodeName = node.Name;
+                LastFailedNodeOp = node.Op;
                 return false;
             }
             else

--- a/src/Lokad.Onnx.Backend/Model.cs
+++ b/src/Lokad.Onnx.Backend/Model.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.Versioning;
 using System.Text;
@@ -14,7 +15,8 @@ namespace Lokad.Onnx
         public static ModelProto? Parse(string onnxInputFilePath)
         {
             var op = Begin("Parsing ONNX model file {f}", onnxInputFilePath);
-            var m =  ModelProto.Parser.ParseFromFile(onnxInputFilePath);
+            var buffer = File.ReadAllBytes(onnxInputFilePath);
+            var m = ModelProto.Parser.ParseFrom(buffer);
             op.Complete();
             return m;
         }

--- a/src/Lokad.Onnx.Backend/Node.cs
+++ b/src/Lokad.Onnx.Backend/Node.cs
@@ -72,7 +72,8 @@ public partial struct Node
     public int[] RequiredInts(string name) => Ints(name) ?? throw new ArgumentException($"The Ints attribute {name} is required but was not found.");
 
 
-    public ITensor? InputTensor(ComputationalGraph graph, int index) => index < Inputs.Length ? graph.GetInputTensor(Inputs[index]) : null;
+    public ITensor? InputTensor(ComputationalGraph graph, int index) =>
+        index < Inputs.Length && !string.IsNullOrEmpty(Inputs[index]) ? graph.GetInputTensor(Inputs[index]) : null;
 
     public ITensor? InputTensorOrAttr(ComputationalGraph graph, int index, string name) => index < Inputs.Length ? graph.GetInputTensor(Inputs[index]) : Attr<ITensor>(name);
 
@@ -134,7 +135,7 @@ public partial struct Node
         OpType.Sqrt => CPU.Sqrt(InputTensor(graph, 0)),
 
         OpType.Conv => CPU.Conv(InputTensor(graph, 0), InputTensor(graph, 1), InputTensor(graph, 2),
-            Attr<string>("auto_pad"), Attr<int[]>("dilations"), Attr<int?>("group"), Attr<int[]>("kernel_shape"), Attr<int[]>("pads"), Attr<int[]>("strides")),
+            Attr<string>("auto_pad"), Ints("dilations"), Attr<int?>("group"), Ints("kernel_shape"), Ints("pads"), Ints("strides")),
 
         OpType.Relu => CPU.Relu(InputTensor(graph, 0)),
 
@@ -157,6 +158,16 @@ public partial struct Node
         OpType.Gather => CPU.Gather(InputTensor(graph, 0), InputTensor(graph, 1), Int("axis")),
 
         OpType.Slice => CPU.Slice(InputTensor(graph, 0), InputTensor(graph, 1), InputTensor(graph, 2), InputTensor(graph, 3), InputTensor(graph, 4)),
+
+        OpType.Equal => CPU.Equal(InputTensor(graph, 0), InputTensor(graph, 1)),
+
+        OpType.Where => CPU.Where(InputTensor(graph, 0), InputTensor(graph, 1), InputTensor(graph, 2)),
+
+        OpType.Expand => CPU.Expand(InputTensor(graph, 0), InputTensor(graph, 1)),
+
+        OpType.Resize => CPU.Resize(InputTensor(graph, 0), InputTensor(graph, 1), InputTensor(graph, 2), InputTensor(graph, 3),
+            Attr<string>("mode", "nearest"), Attr<string>("coordinate_transformation_mode", "half_pixel"), Attr<string>("nearest_mode", "round_prefer_floor"),
+            Attr<float>("cubic_coeff_a", -0.75f), Attr<float>("extrapolation_value", 0f)),
 
         OpType.Unsqueeze => graph.OpsetVersion() switch
         {

--- a/src/Lokad.Onnx.CLI/Program.cs
+++ b/src/Lokad.Onnx.CLI/Program.cs
@@ -384,8 +384,8 @@ class Program : Runtime
             Info("Node {node} has op type: {op}, inputs: {inputs}, outputs: {outputs} and " 
                 + ((n.Attributes is not null && n.Attributes.Count > 0) ?  "the following attributes:" : "no attributes."), 
                 n.Name, n.Op.ToString(), 
-                n.Inputs.Select(t => tensors[t]).ToArray(), 
-                n.Outputs.Select(t => tensors[t]).ToArray());
+                n.Inputs.Select(t => GetTensorDesc(tensors, t)).ToArray(), 
+                n.Outputs.Select(t => GetTensorDesc(tensors, t)).ToArray());
             
             if (n.Attributes is not null && n.Attributes.Count > 0)
             {
@@ -395,6 +395,15 @@ class Program : Runtime
                 }
             }
         }
+    }
+
+    static string GetTensorDesc(Dictionary<string, string> tensors, string name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return "<empty>";
+        }
+        return tensors.TryGetValue(name, out var desc) ? desc : $"{name}<unknown>";
     }
 
     static void PrintModelOps(string file)

--- a/src/Lokad.Onnx.Data/Images.cs
+++ b/src/Lokad.Onnx.Data/Images.cs
@@ -43,6 +43,14 @@ namespace Lokad.Onnx
                         + "_" + $"{image.Height}x{image.Width}_{index}.png");
                     return DenseTensor<float>.OfValues(ImageToArrayF(SaveImage(image, n, saveInput))).WithName(n);
                 }
+                else if (props[0] == "dinov2")
+                {
+                    Info("Converting image data to DINOv2 format tensor data.");
+                    image.Mutate(i => i.Resize(224, 224));
+                    n = Path.Combine(Path.GetDirectoryName(name)!, Path.GetFileNameWithoutExtension(name)
+                        + "_" + $"{image.Height}x{image.Width}_{index}.png");
+                    return DenseTensor<float>.OfValues(ImageToArrayF3(SaveImage(image, n, saveInput))).WithName(n);
+                }
                 else if (char.IsDigit(props[0].Split(':').First()[0]))
                 {
                     if (props[0].Split(':').All(d => Int32.TryParse(d, out var _)))
@@ -97,6 +105,22 @@ namespace Lokad.Onnx
                 for (int j = 0; j < image.Height; j++)
                 {
                     pixels[0, 0, j, i] = ((image[i, j].R + image[i, j].G + image[i, j].B) / 3.0f) / 255.0f;
+                }
+            }
+            return pixels;
+        }
+
+        public static float[,,,] ImageToArrayF3(Image<Rgba32> image)
+        {
+            var pixels = new float[1, 3, image.Height, image.Width];
+            for (int i = 0; i < image.Width; i++)
+            {
+                for (int j = 0; j < image.Height; j++)
+                {
+                    var p = image[i, j];
+                    pixels[0, 0, j, i] = p.R / 255.0f;
+                    pixels[0, 1, j, i] = p.G / 255.0f;
+                    pixels[0, 2, j, i] = p.B / 255.0f;
                 }
             }
             return pixels;

--- a/src/Lokad.Onnx.Tensors/TensorOps.cs
+++ b/src/Lokad.Onnx.Tensors/TensorOps.cs
@@ -232,6 +232,145 @@ where T : unmanaged
 
     public static bool BroadcastShape(Tensor<T> x, Tensor<T> y, out int[] b) => BroadcastShape(x.Dimensions, y.Dimensions, out b);
 
+    public static Tensor<T> BroadcastTo(Tensor<T> input, int[] targetShape)
+    {
+        StartOpStage(OpStage.ValidateArguments);
+        if (targetShape is null) throw new ArgumentNullException(nameof(targetShape));
+
+        var targetRank = targetShape.Length;
+        if (input.Rank > targetRank)
+        {
+            throw new ArgumentException(nameof(targetShape), "Target shape has fewer dimensions than the input tensor.");
+        }
+
+        var paddedInputDims = new int[targetRank];
+        var offset = targetRank - input.Rank;
+        for (int i = 0; i < targetRank; i++)
+        {
+            paddedInputDims[i] = i < offset ? 1 : input.Dimensions[i - offset];
+        }
+
+        var normalizedShape = new int[targetRank];
+        for (int i = 0; i < targetRank; i++)
+        {
+            var dim = targetShape[i];
+            if (dim == -1)
+            {
+                dim = paddedInputDims[i];
+            }
+            if (dim < 1)
+            {
+                throw new ArgumentException(nameof(targetShape), "Target shape dimensions must be positive or -1.");
+            }
+            normalizedShape[i] = dim;
+        }
+
+        StartOpStage(OpStage.CalculateIndices);
+        var result = input;
+        for (int i = 0; i < offset; i++)
+        {
+            result = result.InsertDim(0);
+        }
+        for (int i = 0; i < targetRank; i++)
+        {
+            var dim = result.Dimensions[i];
+            var targetDim = normalizedShape[i];
+            if (dim == targetDim)
+            {
+                continue;
+            }
+            if (dim == 1)
+            {
+                result = result.BroadcastDim(i, targetDim);
+                continue;
+            }
+            throw new ArgumentException(nameof(targetShape), $"Cannot broadcast dimension {dim} to {targetDim}.");
+        }
+        return result;
+    }
+
+    public static Tensor<T> Expand(Tensor<T> data, int[] targetShape)
+    {
+        // NOTE: not perf optimized yet.
+        StartOpStage(OpStage.ValidateArguments);
+        if (data is null) throw new ArgumentNullException(nameof(data));
+        if (targetShape is null) throw new ArgumentNullException(nameof(targetShape));
+        var targetRank = targetShape.Length;
+        if (data.Rank > targetRank)
+        {
+            throw new ArgumentException(nameof(targetShape), "Target shape has fewer dimensions than the input tensor.");
+        }
+
+        StartOpStage(OpStage.CalculateIndices);
+        var result = data;
+        var offset = targetRank - data.Rank;
+        for (int i = 0; i < offset; i++)
+        {
+            result = result.InsertDim(0);
+        }
+
+        for (int i = 0; i < targetRank; i++)
+        {
+            var inputDim = result.Dimensions[i];
+            var targetDim = targetShape[i];
+            if (targetDim == -1)
+            {
+                targetDim = inputDim;
+            }
+            else if (targetDim == 1 && inputDim > 1)
+            {
+                // DINOv2 emits a shape mask that can collapse to ones; treat 1 as "keep dim" here.
+                targetDim = inputDim;
+            }
+
+            if (inputDim == targetDim)
+            {
+                continue;
+            }
+            if (inputDim == 1)
+            {
+                result = result.BroadcastDim(i, targetDim);
+                continue;
+            }
+            throw new ArgumentException(nameof(targetShape), $"Cannot broadcast dimension {inputDim} to {targetDim}.");
+        }
+
+        return result;
+    }
+
+    public static Tensor<bool> Equal(Tensor<T> x, Tensor<T> y)
+    {
+        // NOTE: not perf optimized yet.
+        StartOpStage(OpStage.ValidateArguments);
+        if (!Broadcast(x, y, out var bx, out var by))
+        {
+            throw new ArgumentException("Inputs are not broadcastable.");
+        }
+        var output = DenseTensor<bool>.OfShape(bx.Dimensions.ToArray());
+        for (int i = 0; i < output.Length; i++)
+        {
+            output.SetValue(i, EqualityComparer<T>.Default.Equals(bx.GetValue(i), by.GetValue(i)));
+        }
+        return output;
+    }
+
+    public static Tensor<T> Where(Tensor<bool> condition, Tensor<T> x, Tensor<T> y)
+    {
+        // NOTE: not perf optimized yet.
+        StartOpStage(OpStage.ValidateArguments);
+        if (!Broadcast(x, y, out var bx, out var by))
+        {
+            throw new ArgumentException("Inputs are not broadcastable.");
+        }
+        var bcond = Tensor<bool>.BroadcastTo(condition, bx.Dimensions.ToArray());
+        var output = bx.CloneEmpty();
+        for (int i = 0; i < output.Length; i++)
+        {
+            output.SetValue(i, bcond.GetValue(i) ? bx.GetValue(i) : by.GetValue(i));
+        }
+        return output;
+    }
+
     public static Tensor<byte> Add(Tensor<byte> x, Tensor<byte> y) => x.VectorizedApply((l, r) => (l + r), (l, r) => (byte) (l + r), y);
 
     public static Tensor<byte> Add(Tensor<byte> x, byte y) => x.Apply(l => (byte)(l + y));
@@ -288,6 +427,10 @@ where T : unmanaged
 
     public static Tensor<int> Divide(Tensor<int> x, int y) => x.VectorizedApply(l => l / new Vector<int>(y), l => l / y);
 
+    public static Tensor<long> Divide(Tensor<long> x, Tensor<long> y) => x.Apply((l, r) => l / r, y);
+
+    public static Tensor<long> Divide(Tensor<long> x, long y) => x.Apply(l => l / y);
+
     public static Tensor<float> Divide(Tensor<float> x, Tensor<float> y) => x.VectorizedApply((l, r) => l / r, (l, r) => l / r, y);
 
     public static Tensor<float> Divide(Tensor<float> x, float y) => x.VectorizedApply(l => l / new Vector<float>(y), l => l / y);
@@ -315,6 +458,310 @@ where T : unmanaged
     public static Tensor<float> Sqrt(Tensor<float> x) => x.VectorizedApply(Vector.SquareRoot, MathF.Sqrt);
 
     public static Tensor<double> Sqrt(Tensor<double> x) => x.VectorizedApply(Vector.SquareRoot, Math.Sqrt);
+
+    public static Tensor<float> Resize(Tensor<float> input, int[] sizes, string mode, string coordinateTransformationMode, string nearestMode, float cubicCoeffA)
+    {
+        // NOTE: not perf optimized yet.
+        StartOpStage(OpStage.ValidateArguments);
+        if (input.Rank != 4) throw new ArgumentException(nameof(input), "Resize currently supports only 4D tensors (NCHW).");
+        if (sizes is null || sizes.Length != 4) throw new ArgumentException(nameof(sizes), "Resize sizes must be a 1D array of length 4.");
+
+        var nOut = sizes[0];
+        var cOut = sizes[1];
+        var hOut = sizes[2];
+        var wOut = sizes[3];
+        var nIn = input.Dimensions[0];
+        var cIn = input.Dimensions[1];
+        var hIn = input.Dimensions[2];
+        var wIn = input.Dimensions[3];
+
+        if (nOut != nIn || cOut != cIn)
+        {
+            throw new ArgumentException(nameof(sizes), "Resize currently requires N and C dimensions to remain unchanged.");
+        }
+
+        var output = DenseTensor<float>.OfShape(sizes);
+        var scaleH = (float)hOut / hIn;
+        var scaleW = (float)wOut / wIn;
+
+        float TransformCoordinate(int outIndex, int inSize, int outSize, float scale)
+        {
+            return coordinateTransformationMode switch
+            {
+                "half_pixel" => (outIndex + 0.5f) / scale - 0.5f,
+                "align_corners" => outSize == 1 ? 0f : outIndex * (inSize - 1f) / (outSize - 1f),
+                "asymmetric" => outIndex / scale,
+                _ => throw new NotSupportedException($"coordinate_transformation_mode {coordinateTransformationMode} is not supported."),
+            };
+        }
+
+        int NearestIndex(float coord, int inSize)
+        {
+            var value = nearestMode switch
+            {
+                "floor" => (int)MathF.Floor(coord),
+                "ceil" => (int)MathF.Ceiling(coord),
+                "round_prefer_floor" => (int)MathF.Floor(coord + 0.5f),
+                "round_prefer_ceil" => (int)MathF.Ceiling(coord - 0.5f),
+                _ => throw new NotSupportedException($"nearest_mode {nearestMode} is not supported."),
+            };
+            return Math.Clamp(value, 0, inSize - 1);
+        }
+
+        static float CubicWeight(float x, float a)
+        {
+            var t = MathF.Abs(x);
+            if (t <= 1f)
+            {
+                return ((a + 2f) * t * t * t) - ((a + 3f) * t * t) + 1f;
+            }
+            if (t < 2f)
+            {
+                return (a * t * t * t) - (5f * a * t * t) + (8f * a * t) - (4f * a);
+            }
+            return 0f;
+        }
+
+        for (int n = 0; n < nOut; n++)
+        {
+            for (int c = 0; c < cOut; c++)
+            {
+                for (int oy = 0; oy < hOut; oy++)
+                {
+                    var inY = TransformCoordinate(oy, hIn, hOut, scaleH);
+                    if (mode == "nearest")
+                    {
+                        var ny = NearestIndex(inY, hIn);
+                        for (int ox = 0; ox < wOut; ox++)
+                        {
+                            var inX = TransformCoordinate(ox, wIn, wOut, scaleW);
+                            var nx = NearestIndex(inX, wIn);
+                            output[n, c, oy, ox] = input[n, c, ny, nx];
+                        }
+                    }
+                    else if (mode == "linear")
+                    {
+                        var y0 = MathF.Floor(inY);
+                        var y1 = y0 + 1f;
+                        var y0i = Math.Clamp((int)y0, 0, hIn - 1);
+                        var y1i = Math.Clamp((int)y1, 0, hIn - 1);
+                        var ly = inY - y0;
+                        var wy0 = 1f - ly;
+                        var wy1 = ly;
+                        for (int ox = 0; ox < wOut; ox++)
+                        {
+                            var inX = TransformCoordinate(ox, wIn, wOut, scaleW);
+                            var x0 = MathF.Floor(inX);
+                            var x1 = x0 + 1f;
+                            var x0i = Math.Clamp((int)x0, 0, wIn - 1);
+                            var x1i = Math.Clamp((int)x1, 0, wIn - 1);
+                            var lx = inX - x0;
+                            var wx0 = 1f - lx;
+                            var wx1 = lx;
+                            var v00 = input[n, c, y0i, x0i];
+                            var v01 = input[n, c, y0i, x1i];
+                            var v10 = input[n, c, y1i, x0i];
+                            var v11 = input[n, c, y1i, x1i];
+                            output[n, c, oy, ox] = (v00 * wy0 * wx0) + (v01 * wy0 * wx1) + (v10 * wy1 * wx0) + (v11 * wy1 * wx1);
+                        }
+                    }
+                    else if (mode == "cubic")
+                    {
+                        var yBase = (int)MathF.Floor(inY);
+                        var wy = new float[4];
+                        var yIdx = new int[4];
+                        for (int i = 0; i < 4; i++)
+                        {
+                            var yi = yBase - 1 + i;
+                            yIdx[i] = Math.Clamp(yi, 0, hIn - 1);
+                            wy[i] = CubicWeight(inY - yi, cubicCoeffA);
+                        }
+                        for (int ox = 0; ox < wOut; ox++)
+                        {
+                            var inX = TransformCoordinate(ox, wIn, wOut, scaleW);
+                            var xBase = (int)MathF.Floor(inX);
+                            var wx = new float[4];
+                            var xIdx = new int[4];
+                            for (int i = 0; i < 4; i++)
+                            {
+                                var xi = xBase - 1 + i;
+                                xIdx[i] = Math.Clamp(xi, 0, wIn - 1);
+                                wx[i] = CubicWeight(inX - xi, cubicCoeffA);
+                            }
+                            var sum = 0f;
+                            for (int iy = 0; iy < 4; iy++)
+                            {
+                                var wyv = wy[iy];
+                                for (int ix = 0; ix < 4; ix++)
+                                {
+                                    sum += wyv * wx[ix] * input[n, c, yIdx[iy], xIdx[ix]];
+                                }
+                            }
+                            output[n, c, oy, ox] = sum;
+                        }
+                    }
+                    else
+                    {
+                        throw new NotSupportedException($"Resize mode {mode} is not supported.");
+                    }
+                }
+            }
+        }
+
+        return output;
+    }
+
+    public static Tensor<double> Resize(Tensor<double> input, int[] sizes, string mode, string coordinateTransformationMode, string nearestMode, double cubicCoeffA)
+    {
+        // NOTE: not perf optimized yet.
+        StartOpStage(OpStage.ValidateArguments);
+        if (input.Rank != 4) throw new ArgumentException(nameof(input), "Resize currently supports only 4D tensors (NCHW).");
+        if (sizes is null || sizes.Length != 4) throw new ArgumentException(nameof(sizes), "Resize sizes must be a 1D array of length 4.");
+
+        var nOut = sizes[0];
+        var cOut = sizes[1];
+        var hOut = sizes[2];
+        var wOut = sizes[3];
+        var nIn = input.Dimensions[0];
+        var cIn = input.Dimensions[1];
+        var hIn = input.Dimensions[2];
+        var wIn = input.Dimensions[3];
+
+        if (nOut != nIn || cOut != cIn)
+        {
+            throw new ArgumentException(nameof(sizes), "Resize currently requires N and C dimensions to remain unchanged.");
+        }
+
+        var output = DenseTensor<double>.OfShape(sizes);
+        var scaleH = (double)hOut / hIn;
+        var scaleW = (double)wOut / wIn;
+
+        double TransformCoordinate(int outIndex, int inSize, int outSize, double scale)
+        {
+            return coordinateTransformationMode switch
+            {
+                "half_pixel" => (outIndex + 0.5) / scale - 0.5,
+                "align_corners" => outSize == 1 ? 0d : outIndex * (inSize - 1d) / (outSize - 1d),
+                "asymmetric" => outIndex / scale,
+                _ => throw new NotSupportedException($"coordinate_transformation_mode {coordinateTransformationMode} is not supported."),
+            };
+        }
+
+        int NearestIndex(double coord, int inSize)
+        {
+            var value = nearestMode switch
+            {
+                "floor" => (int)Math.Floor(coord),
+                "ceil" => (int)Math.Ceiling(coord),
+                "round_prefer_floor" => (int)Math.Floor(coord + 0.5),
+                "round_prefer_ceil" => (int)Math.Ceiling(coord - 0.5),
+                _ => throw new NotSupportedException($"nearest_mode {nearestMode} is not supported."),
+            };
+            return Math.Clamp(value, 0, inSize - 1);
+        }
+
+        static double CubicWeight(double x, double a)
+        {
+            var t = Math.Abs(x);
+            if (t <= 1d)
+            {
+                return ((a + 2d) * t * t * t) - ((a + 3d) * t * t) + 1d;
+            }
+            if (t < 2d)
+            {
+                return (a * t * t * t) - (5d * a * t * t) + (8d * a * t) - (4d * a);
+            }
+            return 0d;
+        }
+
+        for (int n = 0; n < nOut; n++)
+        {
+            for (int c = 0; c < cOut; c++)
+            {
+                for (int oy = 0; oy < hOut; oy++)
+                {
+                    var inY = TransformCoordinate(oy, hIn, hOut, scaleH);
+                    if (mode == "nearest")
+                    {
+                        var ny = NearestIndex(inY, hIn);
+                        for (int ox = 0; ox < wOut; ox++)
+                        {
+                            var inX = TransformCoordinate(ox, wIn, wOut, scaleW);
+                            var nx = NearestIndex(inX, wIn);
+                            output[n, c, oy, ox] = input[n, c, ny, nx];
+                        }
+                    }
+                    else if (mode == "linear")
+                    {
+                        var y0 = Math.Floor(inY);
+                        var y1 = y0 + 1d;
+                        var y0i = Math.Clamp((int)y0, 0, hIn - 1);
+                        var y1i = Math.Clamp((int)y1, 0, hIn - 1);
+                        var ly = inY - y0;
+                        var wy0 = 1d - ly;
+                        var wy1 = ly;
+                        for (int ox = 0; ox < wOut; ox++)
+                        {
+                            var inX = TransformCoordinate(ox, wIn, wOut, scaleW);
+                            var x0 = Math.Floor(inX);
+                            var x1 = x0 + 1d;
+                            var x0i = Math.Clamp((int)x0, 0, wIn - 1);
+                            var x1i = Math.Clamp((int)x1, 0, wIn - 1);
+                            var lx = inX - x0;
+                            var wx0 = 1d - lx;
+                            var wx1 = lx;
+                            var v00 = input[n, c, y0i, x0i];
+                            var v01 = input[n, c, y0i, x1i];
+                            var v10 = input[n, c, y1i, x0i];
+                            var v11 = input[n, c, y1i, x1i];
+                            output[n, c, oy, ox] = (v00 * wy0 * wx0) + (v01 * wy0 * wx1) + (v10 * wy1 * wx0) + (v11 * wy1 * wx1);
+                        }
+                    }
+                    else if (mode == "cubic")
+                    {
+                        var yBase = (int)Math.Floor(inY);
+                        var wy = new double[4];
+                        var yIdx = new int[4];
+                        for (int i = 0; i < 4; i++)
+                        {
+                            var yi = yBase - 1 + i;
+                            yIdx[i] = Math.Clamp(yi, 0, hIn - 1);
+                            wy[i] = CubicWeight(inY - yi, cubicCoeffA);
+                        }
+                        for (int ox = 0; ox < wOut; ox++)
+                        {
+                            var inX = TransformCoordinate(ox, wIn, wOut, scaleW);
+                            var xBase = (int)Math.Floor(inX);
+                            var wx = new double[4];
+                            var xIdx = new int[4];
+                            for (int i = 0; i < 4; i++)
+                            {
+                                var xi = xBase - 1 + i;
+                                xIdx[i] = Math.Clamp(xi, 0, wIn - 1);
+                                wx[i] = CubicWeight(inX - xi, cubicCoeffA);
+                            }
+                            var sum = 0d;
+                            for (int iy = 0; iy < 4; iy++)
+                            {
+                                var wyv = wy[iy];
+                                for (int ix = 0; ix < 4; ix++)
+                                {
+                                    sum += wyv * wx[ix] * input[n, c, yIdx[iy], xIdx[ix]];
+                                }
+                            }
+                            output[n, c, oy, ox] = sum;
+                        }
+                    }
+                    else
+                    {
+                        throw new NotSupportedException($"Resize mode {mode} is not supported.");
+                    }
+                }
+            }
+        }
+
+        return output;
+    }
 
     public static Tensor<int> MatMul2D(Tensor<int> x, Tensor<int> y)
     {

--- a/tests/Lokad.Onnx.Backend.Tests/CpuExecutionProviderOpTests.cs
+++ b/tests/Lokad.Onnx.Backend.Tests/CpuExecutionProviderOpTests.cs
@@ -170,4 +170,41 @@ public class CpuExecutionProviderOpTests
         var cstOut = (Tensor<int>)cst.Outputs![0];
         Assert.Equal(42, cstOut[0]);
     }
+
+    [Fact]
+    public void Equal_Where_Expand_Resize()
+    {
+        var a = DenseTensor<long>.OfValues(new long[,] { { 1, 2, 3 } });
+        var b = DenseTensor<long>.OfValues(new long[] { 1, 0, 3 });
+        var eq = CPU.Equal(a, b);
+        Assert.Equal(OpStatus.Success, eq.Status);
+        var eqOut = (Tensor<bool>)eq.Outputs![0];
+        Assert.True(eqOut[0, 0]);
+        Assert.False(eqOut[0, 1]);
+
+        var cond = DenseTensor<bool>.OfValues(new bool[,] { { true }, { false } });
+        var x = DenseTensor<long>.OfValues(new long[,] { { 7, 8, 9 }, { 10, 11, 12 } });
+        var y = DenseTensor<long>.OfValues(new long[] { 1, 1, 1 });
+        var where = CPU.Where(cond, x, y);
+        Assert.Equal(OpStatus.Success, where.Status);
+        var whereOut = (Tensor<long>)where.Outputs![0];
+        Assert.Equal(7, whereOut[0, 0]);
+        Assert.Equal(1, whereOut[1, 2]);
+
+        var expand = CPU.Expand(DenseTensor<float>.OfValues(new float[1, 1, 3] { { { 1f, 2f, 3f } } }),
+            DenseTensor<long>.OfValues(new long[] { 2, 1, 3 }));
+        Assert.Equal(OpStatus.Success, expand.Status);
+        var expandOut = (Tensor<float>)expand.Outputs![0];
+        Assert.Equal(new[] { 2, 1, 3 }, expandOut.Dimensions.ToArray());
+        Assert.Equal(2f, expandOut[1, 0, 1], 5);
+
+        var resizeInput = DenseTensor<float>.OfShape(1, 1, 2, 2);
+        resizeInput.Fill(2f);
+        var sizes = DenseTensor<int>.OfValues(new int[] { 1, 1, 3, 3 });
+        var resize = CPU.Resize(resizeInput, null, null, sizes, "cubic", "half_pixel", "floor", -0.75f, 0f);
+        Assert.Equal(OpStatus.Success, resize.Status);
+        var resizeOut = (Tensor<float>)resize.Outputs![0];
+        Assert.Equal(new[] { 1, 1, 3, 3 }, resizeOut.Dimensions.ToArray());
+        Assert.Equal(2f, resizeOut[0, 0, 1, 1], 5);
+    }
 }

--- a/tests/Lokad.Onnx.Backend.Tests/GraphExecutionDinoV2Tests.cs
+++ b/tests/Lokad.Onnx.Backend.Tests/GraphExecutionDinoV2Tests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Lokad.Onnx.Backend.Tests;
+
+public class GraphExecutionDinoV2Tests
+{
+    [Fact]
+    public void CanInferWithDinoV2Small()
+    {
+        var modelPath = FindModelPath();
+        if (modelPath is null)
+        {
+            return;
+        }
+
+        var graph = Model.Load(modelPath);
+        Assert.NotNull(graph);
+
+        var input = DenseTensor<float>.OfShape(1, 3, 224, 224);
+        input.Fill(0.5f);
+
+        var ok = graph!.Execute(new ITensor[] { input }, true);
+        if (!ok)
+        {
+            var details = $"Failure at node '{graph.LastFailedNodeName}' ({graph.LastFailedNodeOp}): {graph.LastErrorMessage}";
+            Assert.True(ok, details);
+        }
+        var output = (Tensor<float>)graph.Outputs.Values.First();
+        Assert.Equal(new[] { 1, 257, 384 }, output.Dimensions.ToArray());
+
+        var values = output.ToArray();
+        foreach (var v in values)
+        {
+            Assert.False(float.IsNaN(v) || float.IsInfinity(v));
+        }
+    }
+
+    static string? FindModelPath()
+    {
+        var dir = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "models", "dinov2-small-onnx", "model.onnx");
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+            dir = dir.Parent;
+        }
+        return null;
+    }
+}

--- a/tests/Lokad.Onnx.Tensors.Tests/TensorOpsExpandWhereResizeTests.cs
+++ b/tests/Lokad.Onnx.Tensors.Tests/TensorOpsExpandWhereResizeTests.cs
@@ -1,0 +1,75 @@
+using System.Linq;
+
+namespace Lokad.Onnx.Tensors.Tests;
+
+public class TensorOpsExpandWhereResizeTests
+{
+    [Fact]
+    public void Expand_BroadcastsAndHandlesMinusOne()
+    {
+        var data = DenseTensor<int>.OfValues(new int[1, 1, 3] { { { 1, 2, 3 } } });
+        var expanded = Tensor<int>.Expand(data, new[] { 2, 1, -1 });
+
+        Assert.Equal(new[] { 2, 1, 3 }, expanded.Dimensions.ToArray());
+        Assert.Equal(1, expanded[0, 0, 0]);
+        Assert.Equal(2, expanded[1, 0, 1]);
+        Assert.Equal(3, expanded[1, 0, 2]);
+    }
+
+    [Fact]
+    public void Expand_TreatsOnesAsKeepForInputDims()
+    {
+        var data = DenseTensor<int>.OfValues(new int[1, 1, 4] { { { 1, 2, 3, 4 } } });
+        var expanded = Tensor<int>.Expand(data, new[] { 1, 1, 1 });
+
+        Assert.Equal(new[] { 1, 1, 4 }, expanded.Dimensions.ToArray());
+        Assert.Equal(4, expanded[0, 0, 3]);
+    }
+
+    [Fact]
+    public void Equal_BroadcastsAndCompares()
+    {
+        var a = DenseTensor<int>.OfValues(new int[,] { { 1, 2, 3 } });
+        var b = DenseTensor<int>.OfValues(new int[] { 1, 0, 3 });
+
+        var eq = Tensor<int>.Equal(a, b);
+
+        Assert.Equal(new[] { 1, 3 }, eq.Dimensions.ToArray());
+        Assert.True(eq[0, 0]);
+        Assert.False(eq[0, 1]);
+        Assert.True(eq[0, 2]);
+    }
+
+    [Fact]
+    public void Where_BroadcastsAndSelects()
+    {
+        var condition = DenseTensor<bool>.OfValues(new bool[,] { { true }, { false } });
+        var x = DenseTensor<float>.OfValues(new float[,] { { 1f, 2f, 3f }, { 4f, 5f, 6f } });
+        var y = DenseTensor<float>.OfValues(new float[] { 9f, 9f, 9f });
+
+        var result = Tensor<float>.Where(condition, x, y);
+
+        Assert.Equal(new[] { 2, 3 }, result.Dimensions.ToArray());
+        Assert.Equal(1f, result[0, 0], 5);
+        Assert.Equal(3f, result[0, 2], 5);
+        Assert.Equal(9f, result[1, 1], 5);
+    }
+
+    [Fact]
+    public void Resize_Cubic_ConstantInputRemainsConstant()
+    {
+        var input = DenseTensor<float>.OfShape(1, 1, 2, 2);
+        input.Fill(1.5f);
+
+        var resized = Tensor<float>.Resize(input, new[] { 1, 1, 3, 3 }, "cubic", "half_pixel", "floor", -0.75f);
+
+        Assert.Equal(new[] { 1, 1, 3, 3 }, resized.Dimensions.ToArray());
+        for (int y = 0; y < 3; y++)
+        {
+            for (int x = 0; x < 3; x++)
+            {
+                Assert.Equal(1.5f, resized[0, 0, y, x], 5);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implement Expand/Equal/Where/Resize (cubic) and int64 Div support, fix Conv attribute parsing, handle empty inputs in graph/debug output, and add DINOv2 end-to-end coverage. Includes focused tensor/op tests and CPU execution provider tests.